### PR TITLE
[회원] 엔티티 id 필드 nullable 수정

### DIFF
--- a/backend/src/main/java/com/example/Flicktionary/domain/director/entity/Director.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/director/entity/Director.kt
@@ -20,7 +20,7 @@ class Director(
     @OneToMany(mappedBy = "director", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST])
     val series: MutableList<Series> = mutableListOf()
 ) {
-    constructor(id: Long, name: String, profilePath: String) : this(
+    constructor(id: Long, name: String, profilePath: String?) : this(
         id = id,
         name = name,
         profilePath = profilePath,

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/dto/UserAccountDto.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/dto/UserAccountDto.kt
@@ -25,7 +25,7 @@ data class UserAccountDto(
         @JvmStatic
         fun from(userAccount: UserAccount): UserAccountDto {
             return UserAccountDto(
-                userAccount.id ?: 0L,
+                userAccount.id,
                 userAccount.username,
                 userAccount.password,
                 userAccount.email,

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/entity/UserAccount.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/entity/UserAccount.kt
@@ -11,13 +11,6 @@ import java.time.LocalDateTime
 @Entity
 class UserAccount(
     /**
-     * 유저의 고유 ID.
-     */
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null,
-
-    /**
      * 유저의 유저네임(로그인 ID).
      */
     @Column(nullable = false, unique = true)
@@ -49,6 +42,24 @@ class UserAccount(
     @Column(nullable = false)
     var role: UserAccountType = UserAccountType.USER
 ) {
+    /**
+     * 유저의 고유 ID.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private var _id: Long? = null
+
+    var id: Long
+        get() = _id ?: 0
+        set(value) {
+            _id = value
+        }
+
+    constructor(id: Long, username: String, password: String, email: String, nickname: String, role: UserAccountType): this(username, password, email, nickname, role) {
+        this._id = id
+    }
+
     /**
      * 유저의 리프레시 토큰.
      */

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountJwtAuthenticationService.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountJwtAuthenticationService.kt
@@ -31,13 +31,13 @@ class UserAccountJwtAuthenticationService(
     /**
      * 접큰 토큰의 유효기간(초)
      */
-    @Value("\${custom.jwt.access-expire-seconds")
+    @Value("\${custom.jwt.access-expire-seconds}")
     private var accessExpireSeconds: Int = 0
 
     /**
      * 리프레시 토큰의 유효기간(일)
      */
-    @Value("\${custom.jwt.refresh-expire-days")
+    @Value("\${custom.jwt.refresh-expire-days}")
     private var refreshExpireDays: Int = 0
 
     /**


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
`UserAccount` 엔티티 id 필드 nullable 문제 해결

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
`UserAccount` 엔티티의 식별자에 해당하는 `id` 필드를 그대로 `Long?`로 노출하는 대신 내부 필드 `_id`로 변경한 다음 `Long` 타입의 `id`필드로 래핑.
부 생성자도 이 변경점에 맞춰 추가.
`Director` 엔티티의 부 생정자에서 `profilePath`를 `String?`로 받게끔 수정.

Closes #31.