### PR TITLE
[UserAccount] 역직렬화 에러 수정

### DIFF
--- a/backend/src/main/java/com/example/Flicktionary/domain/user/dto/UserAccountDto.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/dto/UserAccountDto.kt
@@ -14,7 +14,7 @@ import com.example.Flicktionary.domain.user.entity.UserAccountType
  * @param role
  */
 data class UserAccountDto(
-    val id: Long,
+    val id: Long?,
     val username: String,
     val password: String,
     val email: String,

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/entity/UserAccount.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/entity/UserAccount.kt
@@ -47,17 +47,10 @@ class UserAccount(
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private var _id: Long? = null
+    var id: Long? = null
 
-    var id: Long
-        get() = _id ?: 0
-        set(value) {
-            _id = value
-        }
-
-    constructor(id: Long, username: String, password: String, email: String, nickname: String, role: UserAccountType): this(username, password, email, nickname, role) {
-        this._id = id
+    constructor(id: Long?, username: String, password: String, email: String, nickname: String, role: UserAccountType): this(username, password, email, nickname, role) {
+        this.id = id
     }
 
     /**

--- a/backend/src/test/java/com/example/Flicktionary/domain/favorite/service/FavoriteServiceTest.kt
+++ b/backend/src/test/java/com/example/Flicktionary/domain/favorite/service/FavoriteServiceTest.kt
@@ -101,14 +101,14 @@ class FavoriteServiceTest {
 
         favorite1 = FavoriteDto(
             id = 0L,
-            userId = testUser.id,
+            userId = testUser.id!!,
             contentType = ContentType.MOVIE,
             contentId = testMovie1.id
         )
 
         favorite2 = FavoriteDto(
             id = 0L,
-            userId = testUser.id,
+            userId = testUser.id!!,
             contentType = ContentType.SERIES,
             contentId = testSeries.id
         )
@@ -119,7 +119,7 @@ class FavoriteServiceTest {
     fun createFavorite_Success() {
         val captor = argumentCaptor<Favorite>()
 
-        given(userAccountRepository.findById(testUser.id))
+        given(userAccountRepository.findById(testUser.id!!))
             .willReturn(Optional.of(testUser))
         given(
             favoriteRepository.existsByUserAccountIdAndContentTypeAndContentId(
@@ -143,7 +143,7 @@ class FavoriteServiceTest {
         assertEquals(favorite1.contentType, result.contentType)
         assertEquals(favorite1.contentId, result.contentId)
 
-        then(userAccountRepository).should().findById(testUser.id)
+        then(userAccountRepository).should().findById(testUser.id!!)
         then(favoriteRepository).should().existsByUserAccountIdAndContentTypeAndContentId(
             favorite1.userId,
             favorite1.contentType,
@@ -156,7 +156,7 @@ class FavoriteServiceTest {
     @Test
     @DisplayName("중복된 즐겨찾기 추가 시 예외 발생")
     fun createFavorite_Duplicate_ThrowsException() {
-        given(userAccountRepository.findById(testUser.id))
+        given(userAccountRepository.findById(testUser.id!!))
             .willReturn(Optional.of(testUser))
         given(
             favoriteRepository.existsByUserAccountIdAndContentTypeAndContentId(
@@ -175,7 +175,7 @@ class FavoriteServiceTest {
             .isInstanceOf(ServiceException::class.java)
             .hasMessage("이미 즐겨찾기에 추가된 항목입니다.")
 
-        then(userAccountRepository).should().findById(testUser.id)
+        then(userAccountRepository).should().findById(testUser.id!!)
         then(favoriteRepository).should().existsByUserAccountIdAndContentTypeAndContentId(
             favorite1.userId,
             favorite1.contentType,
@@ -267,7 +267,7 @@ class FavoriteServiceTest {
 
         // When
         val favorites = favoriteService.getUserFavorites(
-            testUser.id, page, pageSize, sortBy, direction
+            testUser.id!!, page, pageSize, sortBy, direction
         )
         val captured = captor.firstValue
 
@@ -322,7 +322,7 @@ class FavoriteServiceTest {
             )
 
         // When
-        favoriteService.getUserFavorites(testUser.id, page, pageSize, sortBy, direction)
+        favoriteService.getUserFavorites(testUser.id!!, page, pageSize, sortBy, direction)
         val captured = captor.firstValue
 
         // Then
@@ -372,7 +372,7 @@ class FavoriteServiceTest {
             )
 
         // When
-        favoriteService.getUserFavorites(testUser.id, page, pageSize, sortBy, direction)
+        favoriteService.getUserFavorites(testUser.id!!, page, pageSize, sortBy, direction)
         val captured = captor.firstValue
 
         // Then
@@ -400,7 +400,7 @@ class FavoriteServiceTest {
 
         val thrown = catchThrowable {
             favoriteService.getUserFavorites(
-                testUser.id,
+                testUser.id!!,
                 page,
                 pageSize,
                 sortBy,

--- a/backend/src/test/java/com/example/Flicktionary/domain/post/service/PostServiceTest.kt
+++ b/backend/src/test/java/com/example/Flicktionary/domain/post/service/PostServiceTest.kt
@@ -95,7 +95,7 @@ class PostServiceTest {
     @DisplayName("게시글 생성")
     fun createPost() {
         // 유저 Id로 유저를 찾은 뒤 반환 후 저장된 게시글 반환, 테스트 게시글을 생성
-        `when`(userAccountRepository.findById(testUser.id)).thenReturn(Optional.of(testUser))
+        `when`(userAccountRepository.findById(testUser.id!!)).thenReturn(Optional.of(testUser))
         `when`(postRepository.save(any(Post::class.java))).thenReturn(savedPost)
         val testPostDto = postService.create(requestDto)
 

--- a/backend/src/test/java/com/example/Flicktionary/domain/review/service/ReviewServiceTest.kt
+++ b/backend/src/test/java/com/example/Flicktionary/domain/review/service/ReviewServiceTest.kt
@@ -162,7 +162,7 @@ class ReviewServiceTest {
         )
 
         // userAccountRepository.findById()가 호출될 때 testUser를 반환하도록 스텁 처리
-        given(userAccountRepository.findById(testUser.id)).willReturn(Optional.of(testUser))
+        given(userAccountRepository.findById(testUser.id!!)).willReturn(Optional.of(testUser))
 
         val thrownOnEmpty = catchThrowable { reviewService.createReview(reviewEmpty) }
 
@@ -186,7 +186,7 @@ class ReviewServiceTest {
         )
 
         // userAccountRepository.findById()가 호출될 때 testUser를 반환하도록 스텁 처리
-        given(userAccountRepository.findById(testUser.id)).willReturn(Optional.of(testUser))
+        given(userAccountRepository.findById(testUser.id!!)).willReturn(Optional.of(testUser))
 
         val thrown = catchThrowable { reviewService.createReview(reviewNoRating) }
 

--- a/backend/src/test/java/com/example/Flicktionary/domain/user/service/UserAccountServiceTest.kt
+++ b/backend/src/test/java/com/example/Flicktionary/domain/user/service/UserAccountServiceTest.kt
@@ -48,7 +48,7 @@ class UserAccountServiceTest {
         val resUserAccountDto = userAccountService.registerUser(userAccountDto)
 
         assertNotNull(resUserAccountDto)
-        assertEquals(userAccountDto.id, resUserAccountDto.id)
+        assertEquals(userAccountDto.id!!, resUserAccountDto.id)
         assertEquals(userAccountDto.username, resUserAccountDto.username)
         assertEquals(userAccountDto.password, resUserAccountDto.password)
         assertEquals(userAccountDto.email, resUserAccountDto.email)
@@ -83,13 +83,13 @@ class UserAccountServiceTest {
             "newnickname",
             "USER"
         )
-        given(userAccountRepository.findById(userAccountDto.id))
+        given(userAccountRepository.findById(userAccountDto.id!!))
             .willReturn(Optional.of(userAccountDto.toEntity()))
         given(userAccountRepository.save(any(UserAccount::class.java)))
             .willReturn(newUserAccountDto.toEntity())
         given(passwordEncoder.encode(anyString())).willReturn(newUserAccountDto.password)
 
-        val result = userAccountService.modifyUser(userAccountDto.id, newUserAccountDto)
+        val result = userAccountService.modifyUser(userAccountDto.id!!, newUserAccountDto)
 
         assertNotNull(result)
         assertEquals(newUserAccountDto.id, result.id)
@@ -104,13 +104,13 @@ class UserAccountServiceTest {
     @DisplayName("고유 ID로 회원을 조회한다.")
     @Test
     fun givenUserIdWhenFindingUserThenReturnsUser() {
-        given(userAccountRepository.findById(userAccountDto.id))
+        given(userAccountRepository.findById(userAccountDto.id!!))
             .willReturn(Optional.of(userAccountDto.toEntity()))
 
-        val result = userAccountService.getUserById(userAccountDto.id)
+        val result = userAccountService.getUserById(userAccountDto.id!!)
 
         assertNotNull(result)
-        assertEquals(userAccountDto.id, result.id)
+        assertEquals(userAccountDto.id!!, result.id)
         assertEquals(userAccountDto.username, result.username)
         assertEquals(userAccountDto.password, result.password)
         assertEquals(userAccountDto.email, result.email)
@@ -139,7 +139,7 @@ class UserAccountServiceTest {
         val result = userAccountService.getUserByUsername(userAccountDto.username)
 
         assertNotNull(result)
-        assertEquals(userAccountDto.id, result.id)
+        assertEquals(userAccountDto.id!!, result.id)
         assertEquals(userAccountDto.username, result.username)
         assertEquals(userAccountDto.password, result.password)
         assertEquals(userAccountDto.email, result.email)
@@ -163,10 +163,10 @@ class UserAccountServiceTest {
     @DisplayName("회원을 삭제한다.")
     @Test
     fun givenUserIdWhenDeletingUserThenReturnsDeletedUserUsername() {
-        given(userAccountRepository.findById(userAccountDto.id))
+        given(userAccountRepository.findById(userAccountDto.id!!))
             .willReturn(Optional.of(userAccountDto.toEntity()))
 
-        val result = userAccountService.deleteUserById(userAccountDto.id)
+        val result = userAccountService.deleteUserById(userAccountDto.id!!)
 
         assertNotNull(result)
         assertEquals(userAccountDto.username, result)


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
`UserAccount` 관련 역직렬화 밑 영속 에러 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
기존에는 `UserAccount`의 고유값에 해당하는 필드를 `private` 필드로 숨기고 `Long` 타입의 getter/setter 오버라이드로 래핑되어 있었는데, 내부 고유값이 `null`일때 래퍼가 `0`을 반환하기 때문에 이 값을 토대로 JPA가 새로 생성된 `UserAccount`를 영속하려고 할때 예외가 발생했다. 이를 해결하기 위해 래퍼를 삭제하고 필드를 `Long?` 타입으로 그대로 노출하게끔 변경.
`UserAccountDto`에서 `id` 필드가 `Long`이었는데, 이 때문에 회원정보를 클라이언트로부터 전달받을때 `id` 필드가 없으면 역직렬화 단계에서 예외가 발생했다. 이를 해결하기 위해 `id` 필드를 `Long?` 타입으로 변경.
엔티티와 DTO의 변경에 맞춰 테스트 케이스 수정.

Closes #67.