### PR TITLE
fix: 회원정보 수정 오류 해결

### DIFF
--- a/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/controller/UserAccountController.kt
@@ -1,5 +1,7 @@
 package com.example.Flicktionary.domain.user.controller
 
+import com.example.Flicktionary.domain.user.dto.NicknameUpdateRequest
+import com.example.Flicktionary.domain.user.dto.PasswordUpdateRequest
 import com.example.Flicktionary.domain.user.dto.UserAccountDto
 import com.example.Flicktionary.domain.user.service.UserAccountService
 import com.example.Flicktionary.domain.user.service.UserAccountJwtAuthenticationService
@@ -143,8 +145,8 @@ class UserAccountController(
      */
 
     @PatchMapping("/{id}/nickname")
-    fun updateNickname(@PathVariable id: Long, @RequestBody userAccountDto: UserAccountDto): ResponseEntity<ResponseDto<UserAccountDto>> {
-        return ResponseEntity.ok(ResponseDto.ok(userAccountService.modifyNickname(id, userAccountDto)))
+    fun updateNickname(@PathVariable id: Long, @RequestBody request: NicknameUpdateRequest): ResponseEntity<ResponseDto<UserAccountDto>> {
+        return ResponseEntity.ok(ResponseDto.ok(userAccountService.modifyNickname(id, request.nickname)))
     }
 
     /**
@@ -155,8 +157,8 @@ class UserAccountController(
      * @return 수정된 회원의 정보를 포함한 DTO
      */
     @PatchMapping("/{id}/password")
-    fun updatePassword(@PathVariable id: Long, @RequestBody userAccountDto: UserAccountDto): ResponseEntity<ResponseDto<UserAccountDto>> {
-        return ResponseEntity.ok(ResponseDto.ok(userAccountService.modifyPassword(id, userAccountDto)))
+    fun updatePassword(@PathVariable id: Long, @RequestBody request: PasswordUpdateRequest): ResponseEntity<ResponseDto<UserAccountDto>> {
+        return ResponseEntity.ok(ResponseDto.ok(userAccountService.modifyPassword(id, request.password)))
     }
 
     /**

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/dto/NicknameUpdateRequest.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/dto/NicknameUpdateRequest.kt
@@ -1,0 +1,5 @@
+package com.example.Flicktionary.domain.user.dto
+
+data class NicknameUpdateRequest(
+    val nickname: String
+)

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/dto/PasswordUpdateRequest.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/dto/PasswordUpdateRequest.kt
@@ -1,0 +1,5 @@
+package com.example.Flicktionary.domain.user.dto
+
+data class PasswordUpdateRequest(
+    val password: String
+)

--- a/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountService.kt
+++ b/backend/src/main/java/com/example/Flicktionary/domain/user/service/UserAccountService.kt
@@ -59,10 +59,10 @@ class UserAccountService(
      * @param userAccountDto 새로 변경될 닉네임 정보
      * @return 변경된 회원에 해당하는 DTO
      */
-    fun modifyNickname(id: Long, userAccountDto: UserAccountDto): UserAccountDto {
+    fun modifyNickname(id: Long, newNickname: String): UserAccountDto {
         val userAccount = userAccountRepository.findByIdOrNull(id)?:
             throw ServiceException(HttpStatus.NOT_FOUND.value(), "${id}번 유저를 찾을 수 없습니다.")
-        userAccount.nickname = userAccountDto.nickname
+        userAccount.nickname = newNickname
         return UserAccountDto.from(userAccountRepository.save(userAccount))
     }
 
@@ -73,10 +73,10 @@ class UserAccountService(
      * @param userAccountDto 새로 변경될 비밀번호 정보
      * @return 변경된 회원에 해당하는 DTO
      */
-    fun modifyPassword(id: Long, userAccountDto: UserAccountDto): UserAccountDto {
+    fun modifyPassword(id: Long, newPassword: String): UserAccountDto {
         val userAccount = userAccountRepository.findByIdOrNull(id)?:
             throw ServiceException(HttpStatus.NOT_FOUND.value(), "${id}번 유저를 찾을 수 없습니다.")
-        userAccount.password = passwordEncoder.encode("{bcrypt}" + userAccountDto.password)
+        userAccount.password = passwordEncoder.encode("{bcrypt}${newPassword}")
         return UserAccountDto.from(userAccountRepository.save(userAccount))
     }
 


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
회원 닉네임, 비밀번호 수정 요청시 null 문제가 발생하여 다시 수정하였습니다
- 기존 응답용 DTO (UserAccountDto)는 유지
- NicknameUpdateRequest, PasswordUpdateRequest 수정용 DTO 별도로 분리
- Controller, Service에서 이를 이용하여 데이터 수정하도록 변경